### PR TITLE
Feature/font changes

### DIFF
--- a/gitweb.css
+++ b/gitweb.css
@@ -52,6 +52,11 @@ body {
   color: #000000;
 }
 
+/* Monospaced Fonts */
+.sha1, .mode, .diff_tree .list, .pre, .diff, .patchset {
+  font-family: 'Consolas','Bitstream Vera Sans Mono',monospace;
+}
+
 a:link, a:visited {
   color: #4183C4;
   text-decoration: none;
@@ -385,7 +390,6 @@ span.refs a {
 .patchset {
   overflow-x: auto;
   overflow-y: hidden;
-  font-family: 'Consolas','Bitstream Vera Sans Mono',monospace;
 }
 
 .chunk_header {


### PR DESCRIPTION
Made normal fonts be the font that github uses. Made only a select set of classes be monospaced. This really helps with readability. Especially on Linux.
