### PR TITLE
Truncating the description text (with ellipsis) if is greater than fo…

### DIFF
--- a/gitweb.css
+++ b/gitweb.css
@@ -162,6 +162,10 @@ td, th {
   display: inline;
   float: left;
   margin-left: 25px;
+  width: 80%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 a.rss_logo {


### PR DESCRIPTION
If we have a **very long description** it will be truncated **on footer** to not break the layout.
See example below:

![captura de tela 2015-07-09 as 15 54 05](https://cloud.githubusercontent.com/assets/892340/8604120/d1e45404-2652-11e5-812b-e4dbcd48001b.png)