### PR TITLE
Add styling for gitweb timing statistics output

### DIFF
--- a/gitweb.css
+++ b/gitweb.css
@@ -99,6 +99,16 @@ td, th {
   display: none;
 }
 
+#generating_info {
+  font-size: 10px;
+  color: #aaa;
+  text-align: center;
+}
+
+#generating_time, #generating_cmd {
+  font-weight: bold;
+}
+
 /* Page Header
 ---------------------------------------------------------------------------- */
 


### PR DESCRIPTION
When timing statistics are enabled (using the `$feature{'timed'}{'default'} = [1];` config), the status line doesn't have any styling to it.

Before:
![2018-07-27_16 34 26](https://user-images.githubusercontent.com/6866019/43327351-7bd26484-91bb-11e8-80b5-980e01e32578.png)

After:
![2018-07-27_16 37 36](https://user-images.githubusercontent.com/6866019/43327403-9d4d0b14-91bb-11e8-8543-0a9a2b3c990b.png)
